### PR TITLE
fix depoly error : ./app/(tools)/pdf_viewer/page.tsx

### DIFF
--- a/app/(tools)/extract_text_from_pdf/page.tsx
+++ b/app/(tools)/extract_text_from_pdf/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback, useEffect } from "react";
 import Header from "../../components/Header";
 import ExternalScripts from "../../components/ExternalScripts";
-import type { TextItem, PDFDocumentLoadingTask } from "@/types/pdf";
+import type { TextItem, PDFDocumentLoadingTask, TesseractProgress } from "@/types/pdf";
 import Head from "next/head";
 
 export default function ExtractTextFromPDF() {

--- a/app/(tools)/pdf_viewer/page.tsx
+++ b/app/(tools)/pdf_viewer/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import Header from "../../components/Header";
 
 declare const window: WindowWithLibs;
@@ -17,7 +17,7 @@ export default function PDFViewer() {
         const containerRef = useRef<HTMLDivElement>(null);
 
         // Render current page
-        const renderPage = async (pageNum: number) => {
+        const renderPage = useCallback(async (pageNum: number) => {
                 if (!pdfDoc || !canvasRef.current) return;
 
                 try {
@@ -42,7 +42,7 @@ export default function PDFViewer() {
                         console.error("Error rendering page:", err);
                         setError("Failed to render page");
                 }
-        };
+        }, [pdfDoc, scale]);
 
         // Handle file upload
         const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
20:15  Warning: The 'renderPage' function makes the dependencies of useEffect Hook (at line 86) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'renderPage' in its own useCallback() Hook.  react-hooks/exhaustive-deps info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/app/api-reference/config/eslint#disabling-rules Failed to compile.
./app/(tools)/extract_text_from_pdf/page.tsx:188:61 Type error: Cannot find name 'TesseractProgress'.
  186 |                                         'eng',
  187 |                                         {
> 188 |                                                 logger: (m: TesseractProgress) => {
      |                                                             ^
  189 |                                                         if (m.status === 'recognizing text') {
  190 |                                                                 setProgress(`OCR processing page ${i}: ${Math.round(m.progress * 100)}%`);
  191 |                                                         }
Next.js build worker exited with code: 1 and signal: null