### PR TITLE
fix: improve ESLint configuration for interface rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,9 @@
 {
   "extends": "next/core-web-vitals",
   "rules": {
-    "@typescript-eslint/no-empty-interface": "off",
+    "@typescript-eslint/no-empty-interface": ["error", {
+      "allowSingleExtends": true
+    }],
     "@typescript-eslint/no-unused-vars": ["error", {
       "argsIgnorePattern": "^_",
       "varsIgnorePattern": "^_",


### PR DESCRIPTION
- Update no-empty-interface rule to allow single extends:
  - Enables proper window interface augmentation
  - Maintains type safety
  - Follows TypeScript best practices
- Keep flexible no-unused-vars configuration

This commit fixes the build error while maintaining proper code quality standards.